### PR TITLE
fix: isolate per-module register state and fix SoftwareReset

### DIFF
--- a/src/cmis/field.py
+++ b/src/cmis/field.py
@@ -72,14 +72,20 @@ class EEPROM:
 class BaseMemMap(MemMap):
     def __init__(
         self,
-        remote: MemoryAccessor = EEPROM("remote"),
-        local: MemoryAccessor = EEPROM("local"),
+        remote: MemoryAccessor | None = None,
+        local: MemoryAccessor | None = None,
         no_default=False,
         table_filter=None,
     ) -> None:
         super().__init__(no_default=no_default, table_filter=table_filter)
-        self.remote = remote
-        self.local = local
+        # NOTE: default to None and allocate a fresh EEPROM per instance. Using
+        # EEPROM("remote")/EEPROM("local") as default argument values would
+        # evaluate them ONCE at function-definition time, so every BaseMemMap
+        # built without explicit accessors would share the SAME two EEPROM byte
+        # buffers (the classic Python mutable-default pitfall). That aliases the
+        # register state of every emulated module together.
+        self.remote = remote if remote is not None else EEPROM("remote")
+        self.local = local if local is not None else EEPROM("local")
         self.bank = 0
 
     def read(self, bank: int, page: int, offset: int, length: int) -> bytes:

--- a/src/xcvr_emu/server.py
+++ b/src/xcvr_emu/server.py
@@ -11,8 +11,6 @@ import yaml
 from .proto import emulator_pb2 as pb2
 from .transceiver import CMISTransceiver
 
-from cmis import MemMap
-
 # see https://github.com/grpc/grpc/issues/29459#issuecomment-1641587881
 proto_dir = os.path.dirname(pb2.__file__)
 sys.path.append(proto_dir)
@@ -25,7 +23,6 @@ logger = logging.getLogger(__name__)
 class EmulatorServer(emulator_pb2_grpc.SfpEmulatorServiceServicer):
     def __init__(self, config: str = "") -> None:
         super().__init__()
-        self._cmis_mem_map = MemMap()
         self.xcvrs: dict[int, CMISTransceiver] = {}
         self.monitors: list[asyncio.Queue] = []
         if config:
@@ -43,7 +40,10 @@ class EmulatorServer(emulator_pb2_grpc.SfpEmulatorServiceServicer):
                 raise e from None
 
         for k, v in config["transceivers"].items():
-            xcvr = CMISTransceiver(k, v, self._cmis_mem_map)
+            # Each transceiver gets its OWN MemMap (CMISTransceiver defaults
+            # mem_map to a fresh MemMap when None) so emulated modules do not
+            # share/alias register state.
+            xcvr = CMISTransceiver(k, v)
             self.xcvrs[k] = xcvr
 
     async def stop(self):
@@ -61,7 +61,7 @@ class EmulatorServer(emulator_pb2_grpc.SfpEmulatorServiceServicer):
                 f"Transceiver({req.index}) already exists",
             )
 
-        xcvr = CMISTransceiver(req.index, {}, self._cmis_mem_map)
+        xcvr = CMISTransceiver(req.index, {})
         self.xcvrs[req.index] = xcvr
 
         return pb2.CreateResponse()

--- a/src/xcvr_emu/transceiver/transceiver.py
+++ b/src/xcvr_emu/transceiver/transceiver.py
@@ -250,6 +250,14 @@ class CMISTransceiver:
                 if software_reset.value == software_reset.RESET:
                     logger.info("Software reset")
                     self._init()
+                    # SoftwareReset (00h:26.3) is Write-Only / Self-Clearing per
+                    # the CMIS spec: once the module has acted on the trigger the
+                    # bit must read back 0. Clear it here so a subsequent
+                    # read-modify-write of ModuleGlobalControls (e.g. the host
+                    # clearing LowPwrRequestSW) does not re-trigger a reset.
+                    self.mem_map.SoftwareReset.value = (
+                        self.mem_map.SoftwareReset.NO_ACTION
+                    )
 
                 low_pwr = self.mem_map.LowPwrRequestSW
                 if low_pwr.value == low_pwr.LOW_POWER_MODE:


### PR DESCRIPTION

These three defects only surface when the emulator drives MANY modules concurrently (e.g. a full 32-port  bring-up). With a single active module they are invisible, which is why they went unnoticed.

1. Shared EEPROM backing store (mutable default argument), cmis/field.py BaseMemMap.__init__ declared `remote=EEPROM("remote"), local=EEPROM("local")`. Python evaluates default argument values ONCE at function-definition time, so every BaseMemMap/MemMap built without explicit accessors shared the SAME two EEPROM byte buffers. All emulated modules therefore aliased one register space: writing module 0's registers changed all modules. Fix: default the accessors to None and allocate a fresh EEPROM per instance.

2. Shared MemMap across transceivers, xcvr_emu/server.py EmulatorServer created a single self._cmis_mem_map = MemMap() and passed it to every CMISTransceiver, so all modules shared one register map object. CMISTransceiver.__init__ already allocates its own MemMap when mem_map is None, so simply stop passing the shared instance. The now-dead attribute and its `from cmis import MemMap` import are removed.

   Together (1)+(2) give each emulated module fully independent register state, fixing the concurrent-bring-up races ("timeout for ModuleReady", cmis_state=FAILED) seen with many modules.

3. SoftwareReset not self-clearing, xcvr_emu/transceiver/transceiver.py The CMIS SoftwareReset trigger (00h:26.3) is Write-Only / Self-Clearing: once the module acts on it, the bit must read back 0. The emulator left the written bit set in the register map. A host read-modify-write of ModuleGlobalControls (e.g. xcvrd clearing LowPwrRequestSW to bring the module to high power) then wrote the stale SoftwareReset bit back, re-triggering a reset and bouncing the module to ModuleLowPwr in an endless "force Datapath reinit" loop, so the datapath never stayed activated. Fix: clear the bit immediately after the reset is handled.

Verified: two MemMap instances now have independent byte storage (write 0x40 to one reads 0x11 from the other unchanged); and setting SoftwareReset=NO_ACTION after a reset clears byte26 bit3 while preserving the LowPwr bit.